### PR TITLE
chore: use temp kubernetes-purgatory/apisnoop repo

### DIFF
--- a/apps/snoopdb/README.md
+++ b/apps/snoopdb/README.md
@@ -32,7 +32,7 @@ This method requires:
 If you haven't yet, clone this repo and move to the kind repository
 
 ``` shell
-git clone https://github.com/cncf/apisnoop.git && cd apisnoop/kind
+git clone https://github.com/kubernetes-purgatory/apisnoop.git && cd apisnoop/kind
 ```
 
 Then create a kind cluster
@@ -117,7 +117,7 @@ This method requires:
 For this, you will want to clone and move into this repository.
 ```shell
 
-git clone https://github.com/cncf/apisnoop.git && cd apps/snoopDB
+git clone https://github.com/kubernetes-purgatory/apisnoop.git && cd apps/snoopDB
 ```
 
 You can then build the database with docker.

--- a/apps/snoopdb/postgres/initdb/300_fn_load_open_api.sql
+++ b/apps/snoopdb/postgres/initdb/300_fn_load_open_api.sql
@@ -12,7 +12,7 @@ import yaml
 
 K8S_REPO_URL = 'https://raw.githubusercontent.com/kubernetes/kubernetes/'
 OPEN_API_PATH = '/api/openapi-spec/swagger.json'
-RELEASES_URL = 'https://raw.githubusercontent.com/cncf/apisnoop/main/resources/coverage/releases.yaml'
+RELEASES_URL = 'https://raw.githubusercontent.com/kubernetes-purgatory/apisnoop/main/resources/coverage/releases.yaml'
 
 # Get info about latest release from our releases.yaml
 releases = yaml.safe_load(urlopen(RELEASES_URL))

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -10,7 +10,7 @@
         import semver
         from snoopUtils import download_and_process_auditlogs, get_meta
 
-        RELEASES_URL = "https://raw.githubusercontent.com/cncf/apisnoop/master/resources/coverage/releases.yaml"
+        RELEASES_URL = "https://raw.githubusercontent.com/kubernetes-purgatory/apisnoop/master/resources/coverage/releases.yaml"
 
         releases = yaml.safe_load(urlopen(RELEASES_URL))
         latest_release = releases[0]['version']

--- a/apps/snoopdb/postgres/initdb/309_fn_grab_past_releases.sql
+++ b/apps/snoopdb/postgres/initdb/309_fn_grab_past_releases.sql
@@ -10,7 +10,7 @@ def has_open_api (version):
     major = version.split('.')[1]
     return int(major) >= 5 # open api wasn't established until 1.5.0
 
-RELEASES_URL = 'https://raw.githubusercontent.com/cncf/apisnoop/main/resources/coverage/releases.yaml'
+RELEASES_URL = 'https://raw.githubusercontent.com/kubernetes-purgatory/apisnoop/main/resources/coverage/releases.yaml'
 past_releases = yaml.safe_load(urlopen(RELEASES_URL))[1:]
 versions_with_openapi = [release["version"] for release in past_releases if has_open_api(release["version"])]
 return versions_with_openapi

--- a/apps/snoopdb/postgres/initdb/401_proc_update_pod_binding.sql
+++ b/apps/snoopdb/postgres/initdb/401_proc_update_pod_binding.sql
@@ -1,7 +1,7 @@
 create procedure update_pod_binding_events()
   /*
     This is an edge case for an endpoint where it is hit consistently as part of the given test,
-    but is not hit by the test useragent.  See https://github.com/cncf/apisnoop/issues/660
+    but is not hit by the test useragent.  See https://github.com/kubernetes-purgatory/apisnoop/issues/660
    */
   language plpgsql as $$
 begin

--- a/apps/web/src/lib/constants.js
+++ b/apps/web/src/lib/constants.js
@@ -1,7 +1,7 @@
 const head = process.env.HEAD;
 export const RELEASES_URL = head
-  ? `https://raw.githubusercontent.com/cncf/apisnoop/${head}/resources/coverage`
-  : 'https://raw.githubusercontent.com/cncf/apisnoop/main/resources/coverage';
+  ? `https://raw.githubusercontent.com/kubernetes-purgatory/apisnoop/${head}/resources/coverage`
+  : 'https://raw.githubusercontent.com/kubernetes-purgatory/apisnoop/main/resources/coverage';
 // the earliest release we have test data for
 export const PENDING_ENDPOINTS_URL = "https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/pending_eligible_endpoints.yaml";
 export const INELIGIBLE_ENDPOINTS_URL = "https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/ineligible_endpoints.yaml";


### PR DESCRIPTION
update to unbreak site for now.

That said, Netlify won't be installed in this org or repo now so it may not update or unbreak as a result